### PR TITLE
allow animating the flip parent 

### DIFF
--- a/assets/js/hooks/flip.js
+++ b/assets/js/hooks/flip.js
@@ -10,10 +10,11 @@ const Flip = {
     this.duration = parseInt(this.el.dataset.duration || "300");
     this.easing = this.el.dataset.easing || "ease-in-out";
     this.fill = this.el.dataset.fill || "both";
+    this.hasClasses = Object.hasOwn(this.el.dataset, "hasClasses");
   },
   beforeUpdate() {
-    this.child = this.el.children[0];
-    this.currentBounds = this.child.getBoundingClientRect();
+    this.animatingEl = this.hasClasses ? this.el : this.el.children[0];
+    this.currentBounds = this.animatingEl.getBoundingClientRect();
 
     if (this.debug) {
       console.log("Before Update:", {
@@ -27,7 +28,7 @@ const Flip = {
     }
   },
   updated() {
-    const newBounds = this.child.getBoundingClientRect();
+    const newBounds = this.animatingEl.getBoundingClientRect();
 
     const deltaX = this.currentBounds.left - newBounds.left;
     const deltaY = this.currentBounds.top - newBounds.top;
@@ -41,7 +42,7 @@ const Flip = {
       height: newBounds.height,
     };
 
-    const animation = this.child.animate(
+    const animation = this.animatingEl.animate(
       [
         {
           transformOrigin: "top left",
@@ -62,7 +63,7 @@ const Flip = {
     if (this.debug) {
       animation.onfinish = () => {
         requestAnimationFrame(() => {
-          const finalBounds = this.child.getBoundingClientRect();
+          const finalBounds = this.animatingEl.getBoundingClientRect();
 
           console.log("Animation finished:", {
             expected: expectedFinalPosition,

--- a/lib/live_flip.ex
+++ b/lib/live_flip.ex
@@ -46,9 +46,7 @@ defmodule LiveFlip do
   slot :inner_block, required: true, doc: "The content rendered inside of the flip container tag."
 
   def flip_wrap(assigns) do
-    assigns = assign_new(assigns, :has_classes?, fn -> assigns.class != [] end)
-
-    ~H""
+    ~H"""
     <div
       id={@id}
       phx-hook="Flip"
@@ -56,7 +54,7 @@ defmodule LiveFlip do
       data-easing={@easing}
       data-fill={@fill}
       data-debug={@debug}
-      data-has-classes={@has_classes?}
+      data-has-classes={@class != []}
       class={@class}
       {@rest}
     >

--- a/lib/live_flip.ex
+++ b/lib/live_flip.ex
@@ -42,9 +42,12 @@ defmodule LiveFlip do
   attr :fill, :string, required: false, default: "both", doc: "The fill function to pass to the Web Animation API."
   attr :debug, :boolean, default: false, doc: "Add debug logs to the frontend so that you can debug the animations"
   attr :rest, :global, doc: "Additional HTML attributes to add to the flip container tag."
+  attr :class, :list, default: []
   slot :inner_block, required: true, doc: "The content rendered inside of the flip container tag."
 
   def flip_wrap(assigns) do
+    assigns = assign_new(assigns, :has_classes?, fn -> assigns.class != [] end)
+
     ~H"""
     <div
       id={@id}
@@ -53,6 +56,8 @@ defmodule LiveFlip do
       data-easing={@easing}
       data-fill={@fill}
       data-debug={@debug}
+      data-has-classes={@has_classes?}
+      class={@class}
       {@rest}
     >
       {render_slot(@inner_block)}

--- a/lib/live_flip.ex
+++ b/lib/live_flip.ex
@@ -48,7 +48,7 @@ defmodule LiveFlip do
   def flip_wrap(assigns) do
     assigns = assign_new(assigns, :has_classes?, fn -> assigns.class != [] end)
 
-    ~H"""
+    ~H""
     <div
       id={@id}
       phx-hook="Flip"

--- a/lib/live_flip.ex
+++ b/lib/live_flip.ex
@@ -42,7 +42,12 @@ defmodule LiveFlip do
   attr :fill, :string, required: false, default: "both", doc: "The fill function to pass to the Web Animation API."
   attr :debug, :boolean, default: false, doc: "Add debug logs to the frontend so that you can debug the animations"
   attr :rest, :global, doc: "Additional HTML attributes to add to the flip container tag."
-  attr :class, :list, default: []
+
+  attr :class, :list,
+    default: [],
+    doc:
+      "List of classes for the to the flip container tag. If any classes are passed, the container will be the flipped element, otherwise it will be its first child."
+
   slot :inner_block, required: true, doc: "The content rendered inside of the flip container tag."
 
   def flip_wrap(assigns) do

--- a/lib/live_flip.ex
+++ b/lib/live_flip.ex
@@ -46,7 +46,7 @@ defmodule LiveFlip do
   attr :class, :list,
     default: [],
     doc:
-      "List of classes for the to the flip container tag. If any classes are passed, the container will be the flipped element, otherwise it will be its first child."
+      "List of classes for the flip container tag. If any classes are passed, the container itself will be the flipped element. When no classes are passed, the first child of the wrapped element will be the flipped element."
 
   slot :inner_block, required: true, doc: "The content rendered inside of the flip container tag."
 


### PR DESCRIPTION
enables flipping the wrapping element instead of the first child when classes are passed to the `flip_wrap`